### PR TITLE
Add wait_time_seconds receive option

### DIFF
--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -76,6 +76,9 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   # Name of the event field in which to store the  SQS message Sent Timestamp
   config :sent_timestamp_field, :validate => :string
 
+  # Time to spend long polling the queue for a message
+  config :wait_time_seconds, :validate => :number, :default => 10
+
   public
   def aws_service_endpoint(region)
     return {
@@ -107,6 +110,7 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
     receive_opts = {
         :limit => 10,
         :visibility_timeout => 30,
+        :wait_time_seconds => @wait_time_seconds,
         :attributes => [:sent_at]
     }
 


### PR DESCRIPTION
This PR adds a default long polling timeout to 10 seconds as well as a configurable option of wait_time_seconds so that the value can be configured. 

Although not strictly required to function, given that this configuration item could also be done on the SQS queue itself, it may be a good idea to include it in the plugin given the frequency of "sqs input takes too much CPU" questions one finds on the webs. 
