### PR TITLE
Sqs checksum validation toggle

### DIFF
--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -177,9 +177,6 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
       @logger.info("AWS::SQS::Errors::AWS Internal Error ... retrying SQS request with exponential backoff", :queue => @queue, :sleep_time => sleep_time)
       sleep sleep_time
       run_with_backoff(max_time, sleep_time * 2, &block)
-    rescue AWS::SQS::Errors::ChecksumError
-      @logger.error("Checksum validation failed ... skipping message retrieval", :message_id => message.id, :message_md5 => message.md5, :sent_timestamp => message.sent_timestamp, :queue => @queue)
-      return true
     rescue Exception => bang
       @logger.error("Error reading SQS queue.", :error => bang, :queue => @queue)
       return false

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -76,11 +76,21 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   # Name of the event field in which to store the  SQS message Sent Timestamp
   config :sent_timestamp_field, :validate => :string
 
+  # Toggle SQS builtin checksum validation
+  config :sqs_verify_checksums, :validate => :boolean, :default => true
+
   public
   def aws_service_endpoint(region)
     return {
         :sqs_endpoint => "sqs.#{region}.amazonaws.com"
     }
+  end
+
+  public
+  def aws_options_hash
+    super.merge({
+      :sqs_verify_checksums => @sqs_verify_checksums
+    })
   end
 
   public
@@ -161,12 +171,15 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
       sleep sleep_time
       run_with_backoff(max_time, sleep_time * 2, &block)
     rescue AWS::EC2::Errors::InstanceLimitExceeded
-      @logger.warn("AWS::EC2::Errors::InstanceLimitExceeded ... aborting SQS message retreival.")
+      @logger.warn("AWS::EC2::Errors::InstanceLimitExceeded ... aborting SQS message retrieval.")
       return false
     rescue AWS::SQS::Errors::InternalError
       @logger.info("AWS::SQS::Errors::AWS Internal Error ... retrying SQS request with exponential backoff", :queue => @queue, :sleep_time => sleep_time)
       sleep sleep_time
       run_with_backoff(max_time, sleep_time * 2, &block)
+    rescue AWS::SQS::Errors::ChecksumError
+      @logger.error("Checksum validation failed ... skipping message retrieval", :message_id => message.id, :message_md5 => message.md5, :sent_timestamp => message.sent_timestamp, :queue => @queue)
+      return true
     rescue Exception => bang
       @logger.error("Error reading SQS queue.", :error => bang, :queue => @queue)
       return false


### PR DESCRIPTION
Hi, this adds a configuration option to disable Checksum validation and therefore the failure of the entire sqs processing thread due to the exception. 

It's a temporary workaround, and by no means "the proper" fix, in lieu of a much more complex rewrite of the section so as to handle the exception coming out of receive_message followed by some sort of code to skip? delete? the failed checksum message. 
