### PR TITLE
Move the SQS input to use the V2 version of the AWS library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.1.0
+- AWS ruby SDK v2 upgrade
+- Replaces aws-sdk dependencies with mixin-aws
+- Removes unnecessary de-allocation
+- Move the code into smaller methods to allow easier mocking and testing
+- Add the option to configure polling frequency
+- Adding a monkey patch to make sure `LogStash::ShutdownSignal` doesn't get catch by AWS RetryError.

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -138,7 +138,6 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   end # def run
 
   def teardown
-    @sqs = nil
     finished
   end # def teardown
 

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '2.0.0'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-input-sqs'
-  s.version         = '1.0.0'
+  s.version         = '2.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'aws-sdk'
+  s.add_runtime_dependency 'aws-sdk', '~> 2.1.0'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'aws-sdk', '~> 2.1.0'
+  s.add_runtime_dependency "logstash-mixin-aws", ">= 1.0.0"
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/inputs/sqs_spec.rb
+++ b/spec/inputs/sqs_spec.rb
@@ -1,1 +1,170 @@
-require "logstash/devutils/rspec/spec_helper"
+# encoding: utf-8
+require "logstash/inputs/sqs"
+require "logstash/errors"
+require "logstash/event"
+require "logstash/json"
+require "aws-sdk"
+require "spec_helper"
+
+describe LogStash::Inputs::SQS do
+  let(:queue_name) { "the-infinite-pandora-box" }
+  let(:queue_url) { "https://sqs.test.local/#{queue}" }
+  let(:options) do
+    {
+      "region" => "us-east-1",
+      "access_key_id" => "123",
+      "secret_access_key" => "secret",
+      "queue" => queue_name
+    }
+  end
+
+  let(:input) { LogStash::Inputs::SQS.new(options) }
+
+  let(:decoded_message) { { "bonjour" => "awesome" }  }
+  let(:encoded_message)  { double("sqs_message", :body => LogStash::Json::dump(decoded_message)) }
+
+  subject { input }
+
+  let(:mock_sqs) { Aws::SQS::Client.new({ :stub_responses => true }) }
+
+  context "with invalid credentials" do
+    before do
+      expect(Aws::SQS::Client).to receive(:new).and_return(mock_sqs)
+      expect(mock_sqs).to receive(:get_queue_url).with({ :queue_name => queue_name }) { raise Aws::SQS::Errors::ServiceError.new("bad-something", "bad token") }
+    end
+
+    it "raises a Configuration error if the credentials are bad" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  context "valid credentials" do
+    let(:queue) { [] }
+
+    it "doesn't raise an error with valid credentials" do
+      expect(Aws::SQS::Client).to receive(:new).and_return(mock_sqs)
+      expect(mock_sqs).to receive(:get_queue_url).with({ :queue_name => queue_name }).and_return({:queue_url => queue_url })
+      expect { subject.register }.not_to raise_error
+    end
+
+    context "enrich event" do
+      let(:event) { LogStash::Event.new }
+
+      let(:message_id) { "123" }
+      let(:md5_of_body) { "dr strange" }
+      let(:sent_timestamp) { LogStash::Timestamp.new }
+      let(:epoch_timestamp) { (sent_timestamp.utc.to_f * 1000).to_i }
+
+      let(:id_field) { "my_id_field" }
+      let(:md5_field) { "my_md5_field" }
+      let(:sent_timestamp_field) { "my_sent_timestamp_field" }
+
+      let(:message) do
+        double("message", :message_id => message_id, :md5_of_body => md5_of_body, :attributes => { LogStash::Inputs::SQS::SENT_TIMESTAMP  => epoch_timestamp } )
+      end 
+
+      subject { input.add_sqs_data(event, message) }
+
+      context "when the option is specified" do
+        let(:options) do
+          {
+            "region" => "us-east-1",
+            "access_key_id" => "123",
+            "secret_access_key" => "secret",
+            "queue" => queue_name,
+            "id_field" => id_field,
+            "md5_field" => md5_field,
+            "sent_timestamp_field" => sent_timestamp_field
+          }
+        end
+
+        it "add the `message_id`" do
+          expect(subject[id_field]).to eq(message_id)
+        end
+
+        it "add the `md5_of_body`" do
+          expect(subject[md5_field]).to eq(md5_of_body)
+        end
+
+        it "add the `sent_timestamp`" do
+          expect(subject[sent_timestamp_field].to_i).to eq(sent_timestamp.to_i)
+        end
+      end
+
+      context "when the option isn't specified" do
+        it "doesnt add the `message_id`" do
+          expect(subject).not_to include(id_field)
+        end
+
+        it "doesnt add the `md5_of_body`" do
+          expect(subject).not_to include(md5_field)
+        end
+
+        it "doesnt add the `sent_timestamp`" do
+          expect(subject).not_to include(sent_timestamp_field)
+        end
+      end
+    end
+
+    context "when decoding body" do
+      subject { LogStash::Inputs::SQS::new(options.merge({ "codec" => "json" })) }
+
+      it "uses the specified codec" do
+        expect(subject.decode_event(encoded_message)["bonjour"]).to eq(decoded_message["bonjour"])
+      end
+    end
+
+    context "receiving messages" do
+      before do 
+        expect(subject).to receive(:poller).and_return(mock_sqs).at_least(:once)
+      end
+
+      it "creates logstash event" do
+        expect(mock_sqs).to receive(:poll).with(anything()).and_yield([encoded_message], double("stats"))
+        subject.run(queue)
+        expect(queue.pop["bonjour"]).to eq(decoded_message["bonjour"])
+      end
+    end
+
+    context "on errors" do
+      let(:payload) { "Hello world" }
+
+      before do
+        expect(subject).to receive(:poller).and_return(mock_sqs).at_least(:once)
+      end
+
+      context "SQS errors" do
+        it "retry to fetch messages" do
+          # change the poller implementation to raise SQS errors.
+          had_error = false
+          
+          # actually using the child of `Object` to do an expectation of `#sleep`
+          expect(subject).to receive(:sleep).with(LogStash::Inputs::SQS::BACKOFF_SLEEP_TIME)
+          expect(mock_sqs).to receive(:poll).with(anything()).at_most(2) do
+            unless had_error
+              had_error = true
+              raise Aws::SQS::Errors::ServiceError.new("testing", "testing exception")
+            end
+
+            queue << payload
+          end
+
+          subject.run(queue)
+
+          expect(queue.size).to eq(1)
+          expect(queue.pop).to eq(payload)
+        end
+      end
+
+      context "other errors" do
+        it "stops executing the code and raise the exception" do
+          expect(mock_sqs).to receive(:poll).with(anything()).at_most(2) do
+            raise RuntimeError
+          end
+
+          expect { subject.run(queue) }.to raise_error(RuntimeError)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/sqs_spec.rb
+++ b/spec/integration/sqs_spec.rb
@@ -1,0 +1,111 @@
+# encoding: utf-8
+require "logstash/inputs/sqs"
+require "logstash/event"
+require "logstash/json"
+require "aws-sdk"
+require "spec_helper"
+require_relative "../support/helpers"
+require "thread"
+
+Thread.abort_on_exception = true
+
+describe "LogStash::Inputs::SQS integration", :integration => true do
+  let(:decoded_message) { { "drstrange" => "is-he-really-that-strange" } }
+  let(:encoded_message) { LogStash::Json.dump(decoded_message) }
+  let(:queue) { Queue.new }
+
+  let(:input) { LogStash::Inputs::SQS.new(options) }
+
+  context "with invalid credentials" do
+    let(:options) do
+      {
+        "queue" => "do-not-exist",
+        "access_key_id" => "bad_access",
+        "secret_access_key" => "bad_secret_key",
+        "region" => ENV["AWS_REGION"]
+      }
+    end
+
+    subject { input }
+
+    it "raises a Configuration error if the credentials are bad" do
+      expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+    end
+  end
+
+  context "with valid credentials" do
+    let(:options) do
+      {
+        "queue" => ENV["SQS_QUEUE_NAME"],
+        "access_key_id" => ENV['AWS_ACCESS_KEY_ID'],
+        "secret_access_key" => ENV['AWS_SECRET_ACCESS_KEY'],
+        "region" => ENV["AWS_REGION"]
+      }
+    end
+
+    before :each do
+      push_sqs_event(encoded_message)
+      input.register
+      @server = Thread.new { input.run(queue) }
+    end
+
+    after do
+      @server.kill
+    end
+
+    subject { queue.pop }
+
+    it "creates logstash events" do
+      expect(subject["drstrange"]).to eq(decoded_message["drstrange"])
+    end
+
+    context "when the optionals fields are not specified" do
+      let(:id_field) { "my_id_field" }
+      let(:md5_field) { "my_md5_field" }
+      let(:sent_timestamp_field) { "my_sent_timestamp_field" }
+
+      it "add the `message_id`" do
+        expect(subject[id_field]).to be_nil
+      end
+
+      it "add the `md5_of_body`" do
+        expect(subject[md5_field]).to be_nil
+      end
+
+      it "add the `sent_timestamp`" do
+        expect(subject[sent_timestamp_field]).to be_nil
+      end
+
+    end
+
+    context "when the optionals fields are specified" do
+      let(:id_field) { "my_id_field" }
+      let(:md5_field) { "my_md5_field" }
+      let(:sent_timestamp_field) { "my_sent_timestamp_field" }
+
+      let(:options) do
+        {
+          "queue" => ENV["SQS_QUEUE_NAME"],
+          "access_key_id" => ENV['AWS_ACCESS_KEY_ID'],
+          "secret_access_key" => ENV['AWS_SECRET_ACCESS_KEY'],
+          "region" => ENV["AWS_REGION"],
+          "id_field" => id_field,
+          "md5_field" => md5_field,
+          "sent_timestamp_field" => sent_timestamp_field
+        }
+      end
+
+      it "add the `message_id`" do
+        expect(subject[id_field]).not_to be_nil
+      end
+
+      it "add the `md5_of_body`" do
+        expect(subject[md5_field]).not_to be_nil
+      end
+
+      it "add the `sent_timestamp`" do
+        expect(subject[sent_timestamp_field]).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,10 @@
+# encoding: utf-8
+def push_sqs_event(message)
+  client = Aws::SQS::Client.new
+  queue_url = client.get_queue_url(:queue_name => ENV["SQS_QUEUE_NAME"])
+
+  client.send_message({
+    queue_url: queue_url.queue_url,
+    message_body: message,
+  })
+end


### PR DESCRIPTION
This PR includes the following changes:
- Uses V2 version of the library, which resolve the memory leak issue.
- Replace our custom poller with the `QueuePoller` from the AWS library
- Replaced `run_with_backoff` with a non recursive function.
- Adding unit test for the handling of events.
- Adding a small integration test that push an event to a real queue and fetch it.

This PR is build upon @dwagner2301's PR https://github.com/logstash-plugins/logstash-input-sqs/pull/16

Fixes: #17 #11
