### PR TITLE
`message_count` should be `received_message_count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.3
+ - Fixes #22, wrong key use on the stats object
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -147,7 +147,7 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
         end
 
         @logger.debug("SQS Stats:", :request_count => stats.request_count,
-                      :messages_count => stats.message_count,
+                      :received_message_count => stats.received_message_count,
                       :last_message_received_at => stats.last_message_received_at) if @logger.debug?
       end
     end

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
See AWS ruby documentation at http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/QueuePoller/PollerStats.html

Fixes #22
