### PR TITLE
Fix the `Error: uninitialized constant Aws::Client::Errors` error under some circumstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3
+  - Monkey-patch the AWS-SDK to prevent "uninitialized constant" errors.
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,6 +5,7 @@ Contributors:
 * Aaron Broad (AaronTheApe)
 * Colin Surprenant (colinsurprenant)
 * Jordan Sissel (jordansissel)
+* Joshua Spence (joshuaspence)
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
 * Sean Laurent (organicveggie)

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -5,6 +5,13 @@ require "logstash/namespace"
 require "logstash/timestamp"
 require "logstash/plugin_mixins/aws_config"
 require "logstash/errors"
+require 'logstash/inputs/sqs/patch'
+
+# Forcibly load all modules marked to be lazily loaded.
+#
+# It is recommended that this is called prior to launching threads. See
+# https://aws.amazon.com/blogs/developer/threading-with-the-aws-sdk-for-ruby/.
+Aws.eager_autoload!
 
 # Pull events from an Amazon Web Services Simple Queue Service (SQS) queue.
 #

--- a/lib/logstash/inputs/sqs/patch.rb
+++ b/lib/logstash/inputs/sqs/patch.rb
@@ -1,0 +1,21 @@
+# This patch was stolen from logstash-plugins/logstash-output-sqs#20.
+#
+# This patch is a workaround for a JRuby issue which has been fixed in JRuby
+# 9000, but not in JRuby 1.7. See https://github.com/jruby/jruby/issues/3645
+# and https://github.com/jruby/jruby/issues/3920. This is necessary because the
+# `aws-sdk` is doing tricky name discovery to generate the correct error class.
+#
+# As per https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261115960,
+# this patch may be short-lived anyway.
+require 'aws-sdk'
+
+begin
+  old_stderr = $stderr
+  $stderr = StringIO.new
+
+  module Aws
+    const_set(:SQS, Aws::SQS)
+  end
+ensure
+  $stderr = old_stderr
+end

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '3.0.2'
+  s.version         = '3.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pull events from an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/sqs_spec.rb
+++ b/spec/inputs/sqs_spec.rb
@@ -1,10 +1,10 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/sqs"
 require "logstash/errors"
 require "logstash/event"
 require "logstash/json"
 require "aws-sdk"
-require "spec_helper"
 require "ostruct"
 
 describe LogStash::Inputs::SQS do

--- a/spec/integration/sqs_spec.rb
+++ b/spec/integration/sqs_spec.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
+require "spec_helper"
 require "logstash/inputs/sqs"
 require "logstash/event"
 require "logstash/json"
 require "aws-sdk"
-require "spec_helper"
 require_relative "../support/helpers"
 require "thread"
 


### PR DESCRIPTION
Workaround AWS-SDK issue under JRuby
I have occassionally seen the folling error in our Logstash error logs:

```
{"level":"ERROR","loggerName":"logstash.pipeline","timeMillis":1483972688181,"thread":"[main]<sqs","logEvent":{"message":"A plugin had an unrecoverable error. Will restart this plugin.\n  Plugin: <LogStash::Inputs::SQS queue=>\"logstash\", region=>\"us-east-1\", threads=>4, id=>\"6ea8b94e902199fe214a76edafcbc1c24eee708e-3\", enable_metric=>true, codec=><LogStash::Codecs::JSON id=>\"json_d46ee53c-b664-49c2-a64f-c86a0d5b9599\", enable_metric=>true, charset=>\"UTF-8\">, polling_frequency=>20>\n  Error: uninitialized constant Aws::Client::Errors"}}
```

This pull request applies to same monkey-patch as was done in logstash-plugins/logstash-output-sqs#20 in order to workaround jruby/jruby#3920.

---

This the continuation of the work in #31 with the test fixed.