### PR TITLE
Sample policy doesn't match actual policy actions

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -60,8 +60,9 @@ A sample policy is as follows:
             "sqs:GetQueueAttributes",
             "sqs:GetQueueUrl",
             "sqs:ListQueues",
-            "sqs:SendMessage",
-            "sqs:SendMessageBatch"
+            "sqs:DeleteMessage",
+            "sqs:DeleteMessageBatch",
+            "sqs:ReceiveMessage"
           ],
           "Effect": "Allow",
           "Resource": [


### PR DESCRIPTION
The policy required to read SQS includes some policy actions that are not present in the policy sample. Actually the policy sample looks like an example to push data to SQS. To clarify the documentation I suggest to add the required policy actions of this plugin to the policy sample.
