### PR TITLE
add documentation for endpoint, role_arn and role_session_name

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -85,12 +85,15 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-access_key_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-aws_credentials_file>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-id_field>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-md5_field>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-polling_frequency>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-queue>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-region>> |<<string,string>>, one of `["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-central-1", "eu-west-1", "eu-west-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "sa-east-1", "us-gov-west-1", "cn-north-1", "ap-south-1", "ca-central-1"]`|No
+| <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-role_arn>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-role_session_name>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-secret_access_key>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sent_timestamp_field>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-session_token>> |<<string,string>>|No
@@ -133,6 +136,15 @@ file should look like this:
     :secret_access_key: "54321"
 ----------------------------------
 
+[id="plugins-{type}s-{plugin}-endpoint"]
+===== `endpoint`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The endpoint to connect to. By default it is constructed using the value of `region`.
+This is useful when connecting to S3 compatible services, but beware that these aren't
+guaranteed to work correctly with the AWS SDK.
 
 [id="plugins-{type}s-{plugin}-id_field"]
 ===== `id_field` 
@@ -178,10 +190,28 @@ Name of the SQS Queue name to pull messages from. Note that this is just the nam
 [id="plugins-{type}s-{plugin}-region"]
 ===== `region` 
 
-  * Value can be any of: `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2`, `eu-central-1`, `eu-west-1`, `eu-west-2`, `ap-southeast-1`, `ap-southeast-2`, `ap-northeast-1`, `ap-northeast-2`, `sa-east-1`, `us-gov-west-1`, `cn-north-1`, `ap-south-1`, `ca-central-1`
+  * Value type is <<string,string>>
   * Default value is `"us-east-1"`
 
 The AWS Region
+
+[id="plugins-{type}s-{plugin}-role_arn"]
+===== `role_arn`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+The AWS IAM Role to assume, if any.
+This is used to generate temporary credentials, typically for cross-account access.
+See the https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html[AssumeRole API documentation] for more information.
+
+[id="plugins-{type}s-{plugin}-role_session_name"]
+===== `role_session_name`
+
+  * Value type is <<string,string>>
+  * Default value is `"logstash"`
+
+Session name to use when assuming an IAM role.
 
 [id="plugins-{type}s-{plugin}-secret_access_key"]
 ===== `secret_access_key` 

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency "logstash-mixin-aws", ">= 1.0.0"
+  s.add_runtime_dependency 'logstash-mixin-aws', '>= 4.3.0'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Also bump dependency on aws mixin. This is necessary so that the
documentation reflects new features in version 4.3.0 of the
aws mixin.

more info at https://github.com/logstash-plugins/logstash-mixin-aws/pull/37