### PR TITLE
Add support for multiple events inside the same message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Added support for multiple events inside same message from SQS [#48](https://github.com/logstash-plugins/logstash-input-sqs/pull/48/files) 
+
 ## 3.1.1
   - Docs: Set the default_codec doc attribute.
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core', :path => "#{logstash_path}/logstash-core"
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
+
+if RUBY_VERSION == "1.9.3"
+  gem 'rake', '12.2.1'
+end

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-mixin-aws', '>= 4.3.0'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency "logstash-codec-json_lines"
 end
 

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pulls events from an Amazon Web Services Simple Queue Service queue"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Instead of exiting after the first event is extracted by the codec,
iterate through each event processed by @codec.decode
