### PR TITLE
Fix: retry networking errors (with backoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Fix: retry networking errors (with backoff) [#57](https://github.com/logstash-plugins/logstash-input-sqs/pull/57)
+
 ## 3.1.2
   - Added support for multiple events inside same message from SQS [#48](https://github.com/logstash-plugins/logstash-input-sqs/pull/48/files) 
 

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -160,7 +160,6 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
     sleep_time = BACKOFF_SLEEP_TIME
     begin
       block.call
-      sleep_time = BACKOFF_SLEEP_TIME
     rescue Aws::SQS::Errors::ServiceError, Seahorse::Client::NetworkingError => e
       @logger.warn("SQS error ... retrying with exponential backoff", exception_details(e, sleep_time))
       sleep_time = backoff_sleep(sleep_time)

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '3.1.2'
+  s.version         = '3.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pulls events from an Amazon Web Services Simple Queue Service queue"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/sqs_spec.rb
+++ b/spec/inputs/sqs_spec.rb
@@ -178,7 +178,7 @@ describe LogStash::Inputs::SQS do
         expect(subject).to receive(:poller).and_return(mock_sqs).at_least(:once)
       end
 
-      context "SQS errors" do
+      context "SQS error" do
         it "retry to fetch messages" do
           # change the poller implementation to raise SQS errors.
           had_error = false
@@ -201,7 +201,31 @@ describe LogStash::Inputs::SQS do
         end
       end
 
-      context "other errors" do
+      context "SQS error (retries)" do
+        it "retry to fetch messages" do
+          sleep_time = LogStash::Inputs::SQS::BACKOFF_SLEEP_TIME
+          expect(subject).to receive(:sleep).with(sleep_time)
+          expect(subject).to receive(:sleep).with(sleep_time * 2)
+          expect(subject).to receive(:sleep).with(sleep_time * 4)
+
+          error_count = 0
+          expect(mock_sqs).to receive(:poll).with(anything()).at_most(4) do
+            error_count += 1
+            if error_count <= 3
+              raise Aws::SQS::Errors::QueueDoesNotExist.new("testing", "testing exception (#{error_count})")
+            end
+
+            queue << payload
+          end
+
+          subject.run(queue)
+
+          expect(queue.size).to eq(1)
+          expect(queue.pop).to eq(payload)
+        end
+      end
+
+      context "other error" do
         it "stops executing the code and raise the exception" do
           expect(mock_sqs).to receive(:poll).with(anything()).at_most(2) do
             raise RuntimeError


### PR DESCRIPTION
in case of networking errors such as a timeout or a (temporary) failure to resolve DNS names the plugin should retry

resolves #56
resolves #55