### PR TITLE
Add queue_owner_aws_account_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Feature: Add `queue_owner_aws_account_id` parameter for cross-account queues [#60](https://github.com/logstash-plugins/logstash-input-sqs/pull/60)
+
 ## 3.1.3
   - Fix: retry networking errors (with backoff) [#57](https://github.com/logstash-plugins/logstash-input-sqs/pull/57)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -92,6 +92,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-polling_frequency>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-proxy_uri>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-queue>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-queue_owner_aws_account_id>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-region>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-role_arn>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-role_session_name>> |<<string,string>>|No
@@ -187,6 +188,14 @@ URI to proxy server if required
   * There is no default value for this setting.
 
 Name of the SQS Queue name to pull messages from. Note that this is just the name of the queue, not the URL or ARN.
+
+[id="plugins-{type}s-{plugin}-queue_owner_aws_account_id"]
+===== `queue_owner_aws_account_id` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+ID of the AWS account owning the queue if you want to use a https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-basic-examples-of-sqs-policies.html#grant-two-permissions-to-one-account[cross-account queue] with embedded policy. Note that AWS SDK only support numerical account ID and not account aliases.
 
 [id="plugins-{type}s-{plugin}-region"]
 ===== `region` 

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -83,6 +83,9 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   # Name of the SQS Queue name to pull messages from. Note that this is just the name of the queue, not the URL or ARN.
   config :queue, :validate => :string, :required => true
 
+  # Account ID of the AWS account which owns the queue.
+  config :queue_owner_aws_account_id, :validate => :string, :required => false
+
   # Name of the event field in which to store the SQS message ID
   config :id_field, :validate => :string
 
@@ -99,15 +102,22 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
 
   def register
     require "aws-sdk"
-    @logger.info("Registering SQS input", :queue => @queue)
+    @logger.info("Registering SQS input", :queue => @queue, :queue_owner_aws_account_id => @queue_owner_aws_account_id)
 
     setup_queue
   end
 
+  def queue_url(aws_sqs_client)
+    if @queue_owner_aws_account_id
+      return aws_sqs_client.get_queue_url({:queue_name => @queue, :queue_owner_aws_account_id => @queue_owner_aws_account_id})[:queue_url]
+    else
+      return aws_sqs_client.get_queue_url(:queue_name => @queue)[:queue_url]
+    end
+  end
+
   def setup_queue
     aws_sqs_client = Aws::SQS::Client.new(aws_options_hash)
-    queue_url = aws_sqs_client.get_queue_url(:queue_name =>  @queue)[:queue_url]
-    @poller = Aws::SQS::QueuePoller.new(queue_url, :client => aws_sqs_client)
+    @poller = Aws::SQS::QueuePoller.new(queue_url(aws_sqs_client), :client => aws_sqs_client)
   rescue Aws::SQS::Errors::ServiceError, Seahorse::Client::NetworkingError => e
     @logger.error("Cannot establish connection to Amazon SQS", exception_details(e))
     raise LogStash::ConfigurationError, "Verify the SQS queue name and your credentials"

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '3.1.3'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pulls events from an Amazon Web Services Simple Queue Service queue"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/sqs_spec.rb
+++ b/spec/inputs/sqs_spec.rb
@@ -49,6 +49,24 @@ describe LogStash::Inputs::SQS do
       expect { subject.register }.not_to raise_error
     end
 
+    context "when queue_aws_account_id option is specified" do
+      let(:queue_account_id) { "123456789012" }
+      let(:config) do
+        {
+          "region" => "us-east-1",
+          "access_key_id" => "123",
+          "secret_access_key" => "secret",
+          "queue" => queue_name,
+          "queue_owner_aws_account_id" => queue_account_id
+        }
+      end
+      it "passes the option to sqs client" do
+        expect(Aws::SQS::Client).to receive(:new).and_return(mock_sqs)
+        expect(mock_sqs).to receive(:get_queue_url).with({ :queue_name => queue_name, :queue_owner_aws_account_id => queue_account_id }).and_return({:queue_url => queue_url })
+        expect { subject.register }.not_to raise_error
+      end
+    end
+
     context "when interrupting the plugin" do
       before do
         expect(Aws::SQS::Client).to receive(:new).and_return(mock_sqs)


### PR DESCRIPTION
Hello !

This PR is basically a copy of #38  by @majjacz with @ph remarks implemented.

It allow to use a queue shared between two AWS accounts that have been configured with SQS embed access policies instead of an IAM role using the `queue_owner_aws_account_id` option