### PR TITLE
Refactoring: update mixin-aws version to reuse shared code to manage `additional_settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.3.1
-  - Refactoring: used logstash-mixin-aws to leverage shared code to manage `additional_settings` [#62](https://github.com/logstash-plugins/logstash-input-sqs/pull/62)
+  - Refactoring: used logstash-mixin-aws to leverage shared code to manage `additional_settings` [#64](https://github.com/logstash-plugins/logstash-input-sqs/pull/64)
 
 ## 3.3.0
   - Feature: Add `additional_settings` option to fine-grain configuration of AWS client [#61](https://github.com/logstash-plugins/logstash-input-sqs/pull/61)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+  - Refactoring: used logstash-mixin-aws to leverage shared code to manage `additional_settings` [#62](https://github.com/logstash-plugins/logstash-input-sqs/pull/62)
+
 ## 3.3.0
   - Feature: Add `additional_settings` option to fine-grain configuration of AWS client [#61](https://github.com/logstash-plugins/logstash-input-sqs/pull/61)
 

--- a/lib/logstash/inputs/sqs.rb
+++ b/lib/logstash/inputs/sqs.rb
@@ -118,8 +118,7 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
   end
 
   def setup_queue
-    options = symbolized_settings.merge(aws_options_hash || {})
-    aws_sqs_client = Aws::SQS::Client.new(options)
+    aws_sqs_client = Aws::SQS::Client.new(aws_options_hash || {})
     @poller = Aws::SQS::QueuePoller.new(queue_url(aws_sqs_client), :client => aws_sqs_client)
   rescue Aws::SQS::Errors::ServiceError, Seahorse::Client::NetworkingError => e
     @logger.error("Cannot establish connection to Amazon SQS", exception_details(e))
@@ -196,25 +195,6 @@ class LogStash::Inputs::SQS < LogStash::Inputs::Threadable
     details[:sleep_time] = sleep_time if sleep_time
     details[:backtrace] = e.backtrace if @logger.debug?
     details
-  end
-
-  def symbolized_settings
-    @symbolized_settings ||= symbolize_keys_and_cast_true_false(@additional_settings)
-  end
-
-  def symbolize_keys_and_cast_true_false(hash)
-    case hash
-    when Hash
-      symbolized = {}
-      hash.each { |key, value| symbolized[key.to_sym] = symbolize_keys_and_cast_true_false(value) }
-      symbolized
-    when 'true'
-      true
-    when 'false'
-      false
-    else
-      hash
-    end
   end
 
 end # class LogStash::Inputs::SQS

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '3.3.0'
+  s.version         = '3.3.1'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Pulls events from an Amazon Web Services Simple Queue Service queue"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'logstash-mixin-aws', '>= 4.3.0'
+  s.add_runtime_dependency 'logstash-mixin-aws', '>= 5.1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency "logstash-codec-json_lines"

--- a/spec/inputs/sqs_spec.rb
+++ b/spec/inputs/sqs_spec.rb
@@ -80,9 +80,8 @@ describe LogStash::Inputs::SQS do
           expect(Aws::SQS::Client).to receive(:new).and_return(mock_sqs)
           # mock a remote call to retrieve the queue URL
           expect(mock_sqs).to receive(:get_queue_url).with({ :queue_name => queue_name }).and_return({:queue_url => queue_url })
-          expect(subject).to receive(:symbolized_settings) do |arg|
-            expect(arg).to include({:force_path_style => true, :ssl_verify_peer => false, :profile => 'logstash'})
-          end.and_call_original
+
+          expect(subject.aws_options_hash).to include({:force_path_style => true, :ssl_verify_peer => false, :profile => 'logstash'})
 
           expect { subject.register }.not_to raise_error
         end


### PR DESCRIPTION
Refactoring, starting from version `5.1.0` of `mixin-aws` it includes the shared logic for symbolization of  `additional_settings`, this commit updates the dependency and fix the code to reuse that.