### PR TITLE
fix: stop poller when input is being shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.2
+  - Fix an issue that prevented timely shutdown when subscribed to an inactive queue
+
 ## 3.3.1
   - Refactoring: used logstash-mixin-aws to leverage shared code to manage `additional_settings` [#64](https://github.com/logstash-plugins/logstash-input-sqs/pull/64)
 

--- a/logstash-input-sqs.gemspec
+++ b/logstash-input-sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-sqs'
-  s.version         = '3.3.1'
+  s.version         = '3.3.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Pulls events from an Amazon Web Services Simple Queue Service queue"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
> `:stop_polling`
> If you throw :stop_polling from the [#before_request](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SQS/QueuePoller.html#before_request-instance_method) callback, then the poller will exit normally before making the next long poll request.
> -- [`Aws::SQS::QueuePoller#before_request`](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SQS/QueuePoller.html#before_request-instance_method)

Fixes: #33
Closes: #40

